### PR TITLE
Add gedcomx-rs to list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@
 
 ### Rust
 * [rust-gedcom](https://github.com/pirtleshell/rust-gedcom) - Rust library for GEDCOM parsing, with optional serialization to JSON.
+* [gedcomx-rs](https://github.com/ephraimkunz/gedcomx-rs/tree/main/gedcomx) - Rust library for GEDCOM X parsing, with serialization to / from XML and JSON.
 
 ### Scala
 * [gedcom](https://github.com/davidmoten/gedcom) - Scala library to parse GEDCOM files (common genealogy format)


### PR DESCRIPTION
Gedcomx-rs is a Rust library I've created for parsing GEDCOM X in Rust. Add it to the awesome list.