### PR TITLE
Add Editors section with Domorium

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     - [RDF](#rdf)
     - [SQL](#sql)
     - [XML](#xml)
+  - [Editors](#editors)
   - [Parsers](#parsers)
     - [Dart](#dart)
     - [.NET](#net)
@@ -60,6 +61,13 @@
 * [gedcomparser](https://github.com/alfredxiao/gedcomparser) - GEDCOM parser, convert an GEDCOM raw data file into XML
 
 ---
+
+## Editors
+
+* [Domorium for VS Code](https://marketplace.visualstudio.com/items?itemName=domorium.gedcom) - GEDCOM autocomplete, validation as you type, go to definition and safe XREF rename
+* [Domorium for JetBrains IDEs](https://plugins.jetbrains.com/plugin/33323-gedcom) - the same, for IntelliJ IDEA and the rest of the JetBrains platform
+* [Domorium for Obsidian](https://community.obsidian.md/plugins/domorium) - edit `.ged` files inside an Obsidian vault, on desktop and mobile
+* [Domorium Web](https://domorium.com) - validate and edit a GEDCOM file in the browser with nothing to install; the file is read locally and never uploaded
 
 ## Parsers
 


### PR DESCRIPTION
Domorium is GEDCOM language support for editors: autocomplete that knows which tags are legal at the current level, validation as you type, go to definition on cross-references, and safe XREF rename. It ships for VS Code, JetBrains IDEs and Obsidian, and runs in the browser with nothing to install. MIT, and the validation is checked in CI against the twenty-two official GEDCOM 7.0 test files.

I added a new `Editors` section, because as far as I can tell the list has no editor integrations today and none of the three existing sections quite fits — editing a file in place, with the diagnostic on the line that caused it, is not converting, parsing or visualizing. If you would rather fold these into an existing section instead, say which and I will redo it.

The diff is two insertions and changes nothing that is already there.